### PR TITLE
Support advanced configuration values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [Unreleased](https://github.com/idealista/zookeeper-role/tree/develop)
+
+- *[#23](https://github.com/idealista/zookeeper-role/issues/23) Support advanced configuration values* @jperera
 
 - *[#32](https://github.com/idealista/zookeeper-role/issues/32) Fix CVE-2018-10855 (using Ansible > 2.5.5.0)*  @dortegau
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,3 +58,10 @@ zookeeper_env: {}
 zookeeper_force_myid: true
 
 zookeeper_force_reinstall: false
+
+#
+# You can add more zookeper config options using zookeeper_config_map
+#
+# zookeeper_config_map:
+#  - key: traceFile
+#    value: zoo-trace.log

--- a/molecule/default/group_vars/zookeeper.yml
+++ b/molecule/default/group_vars/zookeeper.yml
@@ -12,3 +12,7 @@ zookeeper_hosts:
   - host: zookeeper3
     ip: "{{ (ansible_hostname == 'zookeeper3') | ternary('0.0.0.0', 'zookeeper3') }}"
     id: 3
+
+zookeeper_config_map:
+  - key: traceFile
+    value: zoo-trace.log

--- a/molecule/default/tests/test_advanced_config.yml
+++ b/molecule/default/tests/test_advanced_config.yml
@@ -1,0 +1,5 @@
+file:
+  {{ zookeeper_conf_dir }}/zoo.cfg:
+    exists: true
+    filetype: file
+    contains: ["traceFile=zoo-trace.log"]

--- a/molecule/default/tests/test_zookeeper.yml
+++ b/molecule/default/tests/test_zookeeper.yml
@@ -19,7 +19,6 @@ file:
     owner: {{ zookeeper_user }}
     group: {{ zookeeper_group }}
     filetype: file
-    contains: ["traceFile=zoo-trace.log"]
   {{ zookeeper_conf_dir }}/zookeeper-env.sh:
     exists: true
     owner: {{ zookeeper_user }}

--- a/molecule/default/tests/test_zookeeper.yml
+++ b/molecule/default/tests/test_zookeeper.yml
@@ -19,6 +19,7 @@ file:
     owner: {{ zookeeper_user }}
     group: {{ zookeeper_group }}
     filetype: file
+    contains: ["traceFile=zoo-trace.log"]
   {{ zookeeper_conf_dir }}/zookeeper-env.sh:
     exists: true
     owner: {{ zookeeper_user }}

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -21,3 +21,7 @@ server.{{server.id}}={{server.host}}:2888:3888
 server.{{loop.index}}={{server}}:2888:3888
 {% endif %}
 {% endfor %}
+
+{% for config in zookeeper_config_map %}
+{{config.key}}={{config.value}}
+{% endfor %}


### PR DESCRIPTION

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

You can add any zookeper config value with ansible variable *zookeeper_config_map* (a list of key-value pairs)
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Benefits
Support any configuration value

### Possible Drawbacks
If you put any basic configuration value in the map (e.g., clientPort) the value appears twice in the configuration file

### Applicable Issues
#23 